### PR TITLE
Refactor: 혈당 화면 UI 책임 분리

### DIFF
--- a/presentation/src/main/java/com/dangjang/android/presentation/home/GlucoseActivity.kt
+++ b/presentation/src/main/java/com/dangjang/android/presentation/home/GlucoseActivity.kt
@@ -46,6 +46,7 @@ class GlucoseActivity : FragmentActivity() {
         }
 
         viewModel.getGlucoseList()
+        viewModel.getGlucoseTimeList()
 
         setGlucoseListAdapter()
         setGlucoseTimeSpinner()
@@ -67,19 +68,8 @@ class GlucoseActivity : FragmentActivity() {
     private fun setGlucoseTimeSpinner() {
         val glucoseSpinner: Spinner = binding.glucoseSpinner
 
-        val glucoseTimeList = arrayListOf<String>()
-        glucoseTimeList.add("공복")
-        glucoseTimeList.add("아침 식전")
-        glucoseTimeList.add("아침 식후")
-        glucoseTimeList.add("점심 식전")
-        glucoseTimeList.add("점심 식후")
-        glucoseTimeList.add("저녁 식전")
-        glucoseTimeList.add("저녁 식후")
-        glucoseTimeList.add("취침 전")
-        glucoseTimeList.add("기타")
-
         val glucoseTimeAdapter = object : ArrayAdapter<String>(applicationContext,
-            R.layout.glucose_spinner_dropdown_item, glucoseTimeList),
+            R.layout.glucose_spinner_dropdown_item, viewModel.glucoseTimeList),
             SpinnerAdapter {
             override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
                 // 커스텀한 드롭다운 리스트에 표시할 뷰를 정의합니다.

--- a/presentation/src/main/java/com/dangjang/android/presentation/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/dangjang/android/presentation/home/HomeViewModel.kt
@@ -15,6 +15,9 @@ class HomeViewModel @Inject constructor(
     private val _glucoseList = MutableStateFlow(ArrayList<GlucoseListVO>())
     val glucoseList = arrayListOf<GlucoseListVO>()
 
+    private val _glucoseTimeList = MutableStateFlow(ArrayList<String>())
+    val glucoseTimeList = arrayListOf<String>()
+
     fun getGlucoseList() {
         viewModelScope.launch {
             glucoseList.add(
@@ -39,6 +42,21 @@ class HomeViewModel @Inject constructor(
                             "운동을 하지 않아 혈당이 높아졌어요")
             )
             _glucoseList.emit(glucoseList)
+        }
+    }
+
+    fun getGlucoseTimeList() {
+        viewModelScope.launch {
+            glucoseTimeList.add("공복")
+            glucoseTimeList.add("아침식전")
+            glucoseTimeList.add("아침식후")
+            glucoseTimeList.add("점심식전")
+            glucoseTimeList.add("점심식후")
+            glucoseTimeList.add("저녁식전")
+            glucoseTimeList.add("저녁식후")
+            glucoseTimeList.add("취침전")
+            glucoseTimeList.add("기타")
+            _glucoseTimeList.emit(glucoseTimeList)
         }
     }
 }


### PR DESCRIPTION
## 📌 *Pull requests*

**작업한 브랜치**
- refactor/glucose

**작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
멘토님 코드리뷰를 반영해서 혈당 화면에 대한 리팩토링 진행.
Activity에 있던 glucoseList, glucoseTimeList를 view model로 이동시켰다.

## 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
색상 정보도 이동할까 고민했지만, 색상 정보는 그냥 activity에 있어도 될 것 같다고 판단했다.

## 관련 이슈
- Resolved #41 
