### PR TITLE
Feat: 닉네임 중복확인 버튼 추가

### DIFF
--- a/data/src/main/java/com/dangjang/android/data/interceptor/NetworkInterceptor.kt
+++ b/data/src/main/java/com/dangjang/android/data/interceptor/NetworkInterceptor.kt
@@ -44,7 +44,7 @@ class NetworkInterceptor(
             }
 
             if (errorCode > 399) {
-                throw IOException("$errorMessage")
+                throw IOException("$errorCode : $errorMessage")
             }
         }
 

--- a/data/src/main/java/com/dangjang/android/data/model/dto/DuplicateNicknameDto.kt
+++ b/data/src/main/java/com/dangjang/android/data/model/dto/DuplicateNicknameDto.kt
@@ -1,6 +1,6 @@
 package com.dangjang.android.data.model.dto
 
-import com.dangjang.android.domain.constants.UNKNOWN_BOOLEAN
+import com.dangjang.android.domain.constants.UNKNOWN_STRING
 import com.dangjang.android.domain.model.DuplicateNicknameVO
 import com.google.gson.annotations.SerializedName
 
@@ -9,6 +9,6 @@ data class DuplicateNicknameDto(
 ) {
 
     fun toDomain() = DuplicateNicknameVO(
-        duplicate ?: UNKNOWN_BOOLEAN
+        duplicate.toString() ?: UNKNOWN_STRING
     )
 }

--- a/domain/src/main/java/com/dangjang/android/domain/model/DuplicateNicknameVO.kt
+++ b/domain/src/main/java/com/dangjang/android/domain/model/DuplicateNicknameVO.kt
@@ -1,5 +1,5 @@
 package com.dangjang.android.domain.model
 
 data class DuplicateNicknameVO(
-    val duplicate: Boolean = true
+    val duplicate: String = ""
 )

--- a/presentation/src/main/java/com/dangjang/android/presentation/mypage/MypageViewModel.kt
+++ b/presentation/src/main/java/com/dangjang/android/presentation/mypage/MypageViewModel.kt
@@ -130,7 +130,7 @@ class MypageViewModel @Inject constructor(
         viewModelScope.launch {
             getMypageUseCase.logout("Bearer $accessToken", fcmToken)
                 .onEach {
-                    _signoutFlow.emit(it)
+                    _logoutFlow.emit(it)
                 }
                 .handleErrors()
                 .collect()

--- a/presentation/src/main/res/layout/fragment_signup_nickname.xml
+++ b/presentation/src/main/res/layout/fragment_signup_nickname.xml
@@ -42,20 +42,34 @@
 
         <EditText
             android:id="@+id/nickname_et"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:padding="17sp"
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginEnd="8dp"
             android:background="@drawable/background_et_gray_green"
             android:ems="10"
             android:hint="닉네임을 입력해주세요"
             android:inputType="text"
+            android:padding="17sp"
             android:textColorHint="#939393"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/duplicate_nickname_btn"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/nickname_text_tv" />
+
+        <Button
+            android:id="@+id/duplicate_nickname_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:background="@drawable/background_green_gradient_small"
+            android:text="중복 확인"
+            android:textColor="@color/white"
+            android:textStyle="bold"
+            android:padding="10dp"
+            app:layout_constraintBottom_toBottomOf="@+id/nickname_et"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/nickname_et" />
 
         <TextView
             android:id="@+id/warn_tv"


### PR DESCRIPTION
## 📌 *Pull requests*

**작업한 브랜치**
- feat/duplicateNickname

**작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 닉네임 중복확인 버튼을 추가하고 API 호출 위치를 변경했다.
- 중복확인이 true로 연속으로 들어오면 Text와 Button 속성이 바뀌지 않는 문제를 해결했다.

## 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 백엔드에서 아직 한글 처리가 되지 않은 것 같아 논의가 필요하다.

## 스크린샷
|기능|스크린샷|
|:--:|:--:|
|닉네임 중복확인|<img src = "https://github.com/co-niverse/dangjang-android/assets/70833219/7798055e-1bde-40da-b11e-1bdea6dc42e4" width ="250">|

## 관련 이슈
- Resolved #96 
