### PR TITLE
Fix: 회원가입 provider, accessToken String 처리 제거

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.dangjang.android"
         minSdk 26
         targetSdk 33
-        versionCode 14
-        versionName "1.2.2"
+        versionCode 15
+        versionName "1.2.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders = [KAKAO_APP_KEY: kakao_app_key]

--- a/common-ui/build.gradle
+++ b/common-ui/build.gradle
@@ -11,8 +11,8 @@ android {
         //applicationId "com.dangjang.android.common_ui"
         minSdk 24
         targetSdk 33
-        versionCode 14
-        versionName "1.2.2"
+        versionCode 15
+        versionName "1.2.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -19,8 +19,8 @@ android {
         //applicationId "com.dangjang.android.data"
         minSdk 24
         targetSdk 33
-        versionCode 14
-        versionName "1.2.2"
+        versionCode 15
+        versionName "1.2.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -12,8 +12,8 @@ android {
         //applicationId "com.dangjang.android.domain"
         minSdk 24
         targetSdk 33
-        versionCode 14
-        versionName "1.2.2"
+        versionCode 15
+        versionName "1.2.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/domain/src/main/java/com/dangjang/android/domain/constants/Constants.kt
+++ b/domain/src/main/java/com/dangjang/android/domain/constants/Constants.kt
@@ -32,4 +32,4 @@ const val SEEKBAR_NORMAL_END = 50
 
 //Logging
 const val Log_VERSION = 2
-const val APP_VERSION = "1.2.2"
+const val APP_VERSION = "1.2.3"

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -13,8 +13,8 @@ android {
         //applicationId "com.dangjang.android.presentation"
         minSdk 26
         targetSdk 33
-        versionCode 14
-        versionName "1.2.2"
+        versionCode 15
+        versionName "1.2.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/presentation/src/main/java/com/dangjang/android/presentation/signup/SignupActivity.kt
+++ b/presentation/src/main/java/com/dangjang/android/presentation/signup/SignupActivity.kt
@@ -19,8 +19,8 @@ class SignupActivity: FragmentActivity() {
         val provider = intent.getStringExtra("provider")
         val accessToken = intent.getStringExtra("accessToken")
 
-        viewModel.setProvider("provider!!")
-        viewModel.setAccessToken("accessToken!!")
+        viewModel.setProvider(provider!!)
+        viewModel.setAccessToken(accessToken!!)
 
         val signupNicknameFragment = SignupNicknameFragment()
         supportFragmentManager.beginTransaction().add(R.id.fragment_signup_view, signupNicknameFragment).commit()

--- a/swm-logging/build.gradle
+++ b/swm-logging/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdk 24
         targetSdk 33
-        versionCode 14
-        versionName "1.2.2"
+        versionCode 15
+        versionName "1.2.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## 📌 *Pull requests*

**작업한 브랜치**
- fix/signup

**작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 테스트 할 때 회원가입 provider, accessToken을 String으로 처리했던 부분을 복구한다.
- 1.2.3 출시